### PR TITLE
🛠️ 修复 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@
 
 ## 🧮 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Lixeer/ValleyServer&type=Date)](https://www.star-history.com/#Lixeer/ValleyServer&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Lixeer/ValleyServer&type=Date)](https://star-history.dera.page/#Lixeer/ValleyServer&Date)
 
 ## 🥰贡献者们
 

--- a/README_en.md
+++ b/README_en.md
@@ -75,7 +75,7 @@ A one-click startup package is available in our QQ groups (see below).
 
 ## 🧮 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Lixeer/ValleyServer&type=Date)](https://www.star-history.com/#liyihao1110/ncatbot&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Lixeer/ValleyServer&type=Date)](https://star-history.dera.page/#liyihao1110/ncatbot&Date)
 
 ## 🥰 Contributors
 


### PR DESCRIPTION
## 问题

当前的 Star History 图表因 GitHub 星标 API 的限制已经无法正常显示，影响了项目页面的展示效果。

## 修复

将 Star History 图表链接切换至可正常工作的图表服务，确保星标历史可以继续展示。该修复同时适用于 `README.md` 与 `README_en.md`。